### PR TITLE
ARM: Remove compiler error. Compiler refuses to truncate ulong result…

### DIFF
--- a/silly.d
+++ b/silly.d
@@ -113,7 +113,7 @@ shared static this() {
 			(MonoTime.currTime - started).total!"msecs",
 		);
 
-		return UnitTestResult(passed + failed, passed, false, false);
+		return UnitTestResult(cast(uint)(passed + failed), cast(uint)passed, false, false);
 	};
 }
 


### PR DESCRIPTION
… to uint without cast.

Happens on ARM, with ldc2 1.20.1. Change works on both ARM and x86